### PR TITLE
When the lookup column doesn't exist in the input source or it has a nil...

### DIFF
--- a/lib/itiel/lookup/hash_lookup.rb
+++ b/lib/itiel/lookup/hash_lookup.rb
@@ -7,7 +7,7 @@ module Itiel
         output = []
         input_stream.each do |row|
           origin_column = lookup_columns.first[0].to_sym
-          merge_data    = lookup_stream[row[origin_column]]
+          merge_data    = lookup_stream[row[origin_column]] || { origin_column => nil }
           row.merge!(merge_data)
         end
       end

--- a/test/unit/lookup/hash_lookup_test.rb
+++ b/test/unit/lookup/hash_lookup_test.rb
@@ -75,4 +75,32 @@ describe Itiel::Lookup::HashLookup do
       assert_equal @lookup_stream, @lookup.lookup_stream
     end
   end
+
+  describe 'with nil values in the lookup column' do
+    before do
+      @input.append({ id: 3, author: nil })
+      @expected_output.append({ id: 3, author: nil })
+    end
+
+    describe "#lookup!" do
+      it 'joins the data setting the value to nil' do
+        stub(@lookup).lookup_stream { @lookup_stream }
+        assert_equal @expected_output, @lookup.lookup!(@input)
+      end
+    end
+  end
+
+  describe "When the lookup column doesn't exist in the input_stream" do
+    before do
+      @input.append({ id: 3 })
+      @expected_output.append({ id: 3, author: nil })
+    end
+
+    describe "#lookup!" do
+      it 'joins the data setting the value to nil' do
+        stub(@lookup).lookup_stream { @lookup_stream }
+        assert_equal @expected_output, @lookup.lookup!(@input)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When the lookup column doesn't exist in the input source or it has a nil value, the hash lookup fails
